### PR TITLE
Feature stick mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ build/
 ### Mac OS ###
 .DS_Store
 /demo/
+/.idea/

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryTxAutoConfiguration.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryTxAutoConfiguration.java
@@ -1,0 +1,32 @@
+package com.fastretry.config;
+
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@AutoConfiguration
+@EnableConfigurationProperties(RetryWheelProperties.class)
+@ConditionalOnClass({TransactionTemplate.class, PlatformTransactionManager.class})
+@ConditionalOnBean(PlatformTransactionManager.class)
+public class RetryTxAutoConfiguration {
+
+    /** 业务未定义 TransactionTemplate 时，提供一个默认的编程式事务模板 */
+    @Bean
+    @ConditionalOnMissingBean(TransactionTemplate.class)
+    public TransactionTemplate transactionTemplate(PlatformTransactionManager tm,
+                                                   RetryWheelProperties props) {
+        TransactionTemplate tpl = new TransactionTemplate(tm);
+        tpl.setPropagationBehavior(props.getTx().getPropagation().value());
+        tpl.setIsolationLevel(props.getTx().getIsolation().value());
+        tpl.setReadOnly(props.getTx().isReadOnly());
+        if (props.getTx().getTimeoutSeconds() > 0) {
+            tpl.setTimeout(props.getTx().getTimeoutSeconds());
+        }
+        return tpl;
+    }
+}

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryWheelAutoConfiguration.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryWheelAutoConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.Map;
@@ -97,9 +98,10 @@ public class RetryWheelAutoConfiguration {
                                    @Autowired BackoffRegistry backoffRegistry,
                                    @Autowired(required = false)  FailureDecider failureDecider,
                                    RetryMetrics meter,
+                                   TransactionTemplate tt,
                                    RetryWheelProperties props) {
         return new RetryEngine(timer, dispatchExecutor, handlerExecutor, mapper, serializer, handlers,
-                backoffRegistry, failureDecider, meter, props);
+                backoffRegistry, failureDecider, meter, tt, props);
     }
 
     /**

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryWheelAutoConfiguration.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/config/RetryWheelAutoConfiguration.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -99,9 +100,10 @@ public class RetryWheelAutoConfiguration {
                                    @Autowired(required = false)  FailureDecider failureDecider,
                                    RetryMetrics meter,
                                    TransactionTemplate tt,
-                                   RetryWheelProperties props) {
+                                   RetryWheelProperties props,
+                                   ApplicationContext applicationContext) {
         return new RetryEngine(timer, dispatchExecutor, handlerExecutor, mapper, serializer, handlers,
-                backoffRegistry, failureDecider, meter, tt, props);
+                backoffRegistry, failureDecider, meter, tt, applicationContext, props);
     }
 
     /**

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/core/RetryEngine.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/core/RetryEngine.java
@@ -2,26 +2,30 @@ package com.fastretry.core;
 
 import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.fastretry.config.RetryWheelProperties;
+import com.fastretry.core.backoff.BackoffRegistry;
 import com.fastretry.core.metric.RetryMetrics;
+import com.fastretry.core.spi.FailureDecider;
+import com.fastretry.core.spi.PayloadSerializer;
+import com.fastretry.core.spi.RetryTaskHandler;
 import com.fastretry.mapper.RetryTaskMapper;
 import com.fastretry.model.SubmitOptions;
 import com.fastretry.model.ctx.RetryTaskContext;
 import com.fastretry.model.entity.RetryTaskEntity;
 import com.fastretry.model.enums.TaskState;
-import com.fastretry.core.spi.FailureDecider;
-import com.fastretry.core.spi.PayloadSerializer;
-import com.fastretry.core.spi.RetryTaskHandler;
-import com.fastretry.core.backoff.BackoffRegistry;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.util.NamedThreadFactory;
 import io.netty.util.HashedWheelTimer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,6 +34,9 @@ public class RetryEngine implements SmartLifecycle {
 
     /** 时间轮 */
     private final HashedWheelTimer timer;
+
+    /** 扫描线程池 */
+    private final ExecutorService scanExecutor;
 
     /** 任务调度线程池 */
     private final ExecutorService dispatchExecutor;
@@ -59,6 +66,9 @@ public class RetryEngine implements SmartLifecycle {
     /** 节点id */
     private final String nodeId = UUID.randomUUID().toString();
 
+    /** 编程式事务 */
+    private TransactionTemplate tt;
+
     /** 配置 */
     private final RetryWheelProperties props;
 
@@ -71,6 +81,7 @@ public class RetryEngine implements SmartLifecycle {
                        BackoffRegistry backoffRegistry,
                        FailureDecider failureDecider,
                        RetryMetrics meter,
+                       TransactionTemplate tt,
                        RetryWheelProperties props) {
         this.timer = timer;
         this.dispatchExecutor = dispatchExecutor;
@@ -81,7 +92,10 @@ public class RetryEngine implements SmartLifecycle {
         this.backoff = backoffRegistry;
         this.failureDecider = failureDecider;
         this.meter = meter;
+        this.tt = tt;
         this.props = props;
+        this.scanExecutor = Executors.newFixedThreadPool(props.getStick().isEnable() ? 2 : 1,
+                new NamedThreadFactory("retry-scan-exec"));
     }
 
     @Override
@@ -103,6 +117,230 @@ public class RetryEngine implements SmartLifecycle {
     @Override
     public boolean isRunning() {
         return false;
+    }
+
+    /**
+     * 扫表
+     */
+    private void scheduleScanner(long delayMs) {
+        Runnable scan = () -> {
+            if (!running.get()) {
+                log.warn("[ScheduleScanner] retry engine is stop, stop task scan");
+                return;
+            }
+            try {
+                scanExecutor.execute(this::lockMarkRunningBatch);
+                if (props.getStick().isEnable()) {
+                    scanExecutor.execute(this::lockTakeOver);
+                }
+            } catch (Exception e) {
+                log.error("[ScheduleScanner]  scan task error", e);
+                meter.incScanErr();
+            } finally {
+                // 将下轮scan挂到时间轮
+                scheduleScanner(props.getScan().getPeriod().toMillis());
+            }
+        };
+        // scan任务挂在delayMs后的时间轮上
+        timer.newTimeout(t -> scan.run(), delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * 行锁抢占 + 事务来更新状态为RUNNING
+     */
+    private void lockMarkRunningBatch() {
+        List<RetryTaskEntity> tasks = tt.execute(status -> {
+            int batch = props.getScan().getBatch();
+            // 加行锁获取任务
+            List<Long> ids = mapper.lockDueTaskIds(batch);
+            // 同一事务下加行锁后更新状态RUNNING
+            List<RetryTaskEntity> ret = List.of();
+            if (!ids.isEmpty()) {
+                if (props.getStick().isEnable()) {
+                    // 启用粘滞模式
+                    mapper.markRunningAndOwnBatch(ids, nodeId, props.getStick().getLeaseTtl().toSeconds());
+                } else {
+                    mapper.markRunningBatch(ids, nodeId);
+                }
+                ret = mapper.selectBatchIds(ids);
+            }
+            return ret;
+        });
+        // 提交到调度线程池
+        if (tasks != null && !tasks.isEmpty()) {
+            tasks.forEach(this::dispatch);
+        }
+    }
+
+    /**
+     * 行锁抢占 + 事务来扫描需要被接管的任务
+     */
+    private void lockTakeOver() {
+        List<RetryTaskEntity> tasks = tt.execute(status -> {
+            int batch = props.getScan().getBatch();
+            List<Long> ids = mapper.findLeaseExpired(batch);
+
+            List<RetryTaskEntity> ret = List.of();
+            if (!ids.isEmpty()) {
+                mapper.tryTakeover(ids, nodeId, props.getStick().getLeaseTtl().toSeconds());
+                log.info("[Takeover Scan] the current service has taken over the task ids={}", ids);
+                ret = mapper.selectBatchIds(ids);
+            }
+            return ret;
+        });
+        // 提交到调度线程池
+        if (tasks != null && !tasks.isEmpty()) {
+            tasks.forEach(this::dispatch);
+        }
+    }
+
+    /**
+     * 线程池调度执行任务
+     */
+    private void dispatch(RetryTaskEntity task) {
+        dispatchExecutor.execute(() -> {
+            try {
+                // check过期/截止线, 标记进入死信队列
+                if (task.getDeadlineTime() != null
+                        && LocalDateTime.now().isAfter(task.getDeadlineTime())) {
+                    mapper.markDeadLetter(task.getId(), task.getVersion(), "[Dispatch] Expired deadline");
+                    log.warn("[Dispatch] task expired status modify to deadLetter, id={}", task.getId());
+                    return;
+                }
+
+                // 已被接管
+                if (StringUtils.isNotEmpty(task.getOwnerNodeId()) && !nodeId.equals(task.getOwnerNodeId())) {
+                    log.warn("[Dispatch] task id={} has been taken over by another instance", task.getId());
+                    return;
+                }
+
+                RetryTaskHandler<?> h = handlers.get(task.getBizType());
+                // 对应任务的执行器不存在, 标记进入死信队列
+                if (h == null) {
+                    mapper.markDeadLetter(task.getId(), task.getVersion(), "No handler");
+                    log.warn("[Dispatch] task no handler, status modify to deadLetter, id={}", task.getId());
+                    return;
+                }
+
+                RetryTaskContext context = RetryTaskContext.builder()
+                        .nodeId(nodeId)
+                        .bizType(task.getBizType())
+                        .taskId(task.getTaskId())
+                        .tenantId(task.getTenantId())
+                        .headers(Map.of())
+                        .attempt(task.getRetryCount())
+                        .maxRetry(task.getMaxRetry())
+                        .deadline(task.getDeadlineTime() == null ? null : task.getDeadlineTime().toInstant(ZoneOffset.ofHours(8)))
+                        .build();
+
+                // 执行前续约
+                // now 当前时间 + executionTimeout 最大执行时间 > LeaseExpireAt 租约到期时间 - renewAhead 提前续约窗口
+                if (props.getStick().isEnable() && task.getLeaseExpireAt() != null
+                        && LocalDateTime.now().plusSeconds(task.getExecuteTimeoutMs().longValue())
+                            .isAfter(task.getLeaseExpireAt().minusSeconds(props.getStick().getRenewAhead().toSeconds()))) {
+                    // 为防止时钟漂移, 最终以数据库时钟为准
+                    mapper.renewLease(task.getId(), nodeId, props.getStick().getLeaseTtl().toSeconds(), props.getStick().getRenewAhead().toSeconds());
+                }
+
+                // 执行 with 超时
+                Future<Boolean> f = handlerExecutor.submit(() -> executeWith(h, task, context));
+
+                boolean ret = false;
+                try {
+                    ret = f.get(task.getExecuteTimeoutMs(), TimeUnit.MILLISECONDS);
+                } catch (TimeoutException te) {
+                    f.cancel(true);
+                    handleFailure(task, new RuntimeException("[Dispatch] Handler execute time out"), context);
+                    return;
+                } catch (Throwable e) {
+                    handleFailure(task, e, context);
+                    return;
+                }
+
+                if (ret) {
+                    mapper.markSuccess(task.getId(), task.getVersion());
+                    meter.incSuccess();
+                } else {
+                    handleFailure(task, new RuntimeException("[Dispatch] Handler returned false"), context);
+                }
+            } catch (Throwable ex) {
+                log.error("[Dispatch] fatal error, {}", ex.getMessage());
+                throw ex;
+            }
+        });
+    }
+
+    /**
+     * 具体执行
+     */
+    private <T> boolean executeWith(RetryTaskHandler<T> handler,
+                                    RetryTaskEntity task, RetryTaskContext ctx) throws Exception {
+        // 反序列化为T, 类型安全
+        T payload = serializer.deserialize(task.getPayload(), handler.payloadType());
+        // 调用handler
+        return handler.execute(ctx, payload);
+    }
+
+    /**
+     * 失败处理
+     */
+    private void handleFailure(RetryTaskEntity task, Throwable ex, RetryTaskContext ctx) {
+        log.info("[HandlerFailure] task execute failed, id={}, err={}, stickMode={}",
+                task.getId(), ex.getMessage(), props.getStick().isEnable());
+        meter.incFailed();
+
+        boolean retryable = failureDecider.isRetryable(ex, ctx);
+        int nextAttempt = task.getRetryCount() + 1;
+        // 截断4000字符
+        String err = "null";
+        if (!StringUtils.isBlank(ex.getMessage())) {
+            err = ex.getMessage().substring(Math.min(4000, ex.getMessage().length()));
+        }
+        // 不可重试或者达到最大重试次数, 将任务标记死信队列
+        if (!retryable || nextAttempt > task.getMaxRetry()) {
+            log.warn("[HandlerFailure] when the maximum retry count is reached, mark the task as dead letter queue ");
+            mapper.markDeadLetter(task.getId(), task.getVersion(), err);
+            meter.incDlq();
+            return;
+        }
+
+        Instant now = Instant.now(), deadline = task.getDeadlineTime() == null ? null : task.getDeadlineTime().toInstant(ZoneOffset.ofHours(8));
+        Instant nextTs = backoff.resolve(task.getBackoffStrategy())
+                .next(now, nextAttempt, deadline, task, props);
+        // 下次执行时间间隔
+        long delay = nextTs.toEpochMilli() - now.toEpochMilli();
+
+        // 设置下次触发时间, 非粘滞模式
+        if (!props.getStick().isEnable()) {
+            mapper.markPendingWithNext(
+                    task.getId(), task.getVersion(), LocalDateTime.ofInstant(nextTs, ZoneOffset.ofHours(8)), nextAttempt, err);
+        } else {
+            // 粘滞模式 RUNNING 内循环, 不回PENDING 不换owner
+            if (delay > (props.getStick().getLeaseTtl().toMillis() - props.getStick().getRenewAhead().toMillis())) {
+                // 可能需要续约, 下次执行时间点在续约窗口内
+                mapper.renewLease(task.getId(), nodeId, props.getStick().getLeaseTtl().toSeconds(), props.getStick().getRenewAhead().toSeconds());
+            }
+            // 本地重试写回部分任务信息
+            int st = mapper.updateForLocalRetry(task.getId(), nodeId, task.getVersion(),
+                    LocalDateTime.ofInstant(nextTs, ZoneOffset.ofHours(8)),
+                    nextAttempt, err);
+            if (st > 0) {
+                // 更新本地任务重试次数及版本
+                task.setRetryCount(nextAttempt);
+                task.setVersion(task.getVersion() + 1);
+            }
+            // 将重试任务粘滞到本地时间轮
+            timer.newTimeout(t -> dispatch(task), delay, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /**
+     * 小工具：剥离 CompletionException/ExecutionException 外壳
+     */
+    private static Throwable unwrap(Throwable ex) {
+        if (ex instanceof CompletionException ce && ce.getCause() != null) return ce.getCause();
+        if (ex instanceof ExecutionException ee && ee.getCause() != null) return ee.getCause();
+        return ex;
     }
 
     public String submit(String bizType, Object payload, SubmitOptions opt) {
@@ -128,149 +366,5 @@ public class RetryEngine implements SmartLifecycle {
         mapper.insert(entity);
         meter.incEnqueued();
         return entity.getTaskId();
-    }
-
-    /**
-     * 将"待执行db任务"投递到执行线程池中
-     */
-    private void scheduleScanner(long delayMs) {
-        Runnable scan = () -> {
-            if (!running.get()) {
-                log.warn("retry engine is stop, stop task scan");
-                return;
-            }
-            try {
-                int batch = props.getScan().getBatch();
-                // 加行锁获取任务
-                List<Long> ids = mapper.lockDueTaskIds(batch);
-                if (ids.isEmpty()) {
-                    return;
-                }
-                mapper.markRunningBatch(ids, nodeId);
-                ids.forEach(this::dispatch);
-            } catch (Exception e) {
-                log.error("scan task error", e);
-                meter.incScanErr();
-            } finally {
-                // 将下轮scan挂到时间轮
-                scheduleScanner(props.getScan().getPeriod().toMillis());
-            }
-        };
-        // scan任务挂在delayMs后的时间轮上
-        timer.newTimeout(t -> scan.run(), delayMs, TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * 线程池调度执行
-     */
-    private void dispatch(Long id) {
-        dispatchExecutor.execute(() -> {
-            try {
-                RetryTaskEntity task = mapper.selectById(id);
-                if (task == null) {
-                    log.warn("task not found, id={}", id);
-                    return;
-                }
-
-                // check过期/截止线, 标记进入死信队列
-                if (task.getDeadlineTime() != null
-                        && LocalDateTime.now().isAfter(task.getDeadlineTime())) {
-                    mapper.markDeadLetter(task.getId(), task.getVersion(), "Expired deadline");
-                    log.warn("task expired status modify to deadLetter, id={}", task.getId());
-                    return;
-                }
-
-                RetryTaskHandler<?> h = handlers.get(task.getBizType());
-                // 对应任务的执行器不存在, 标记进入死信队列
-                if (h == null) {
-                    mapper.markDeadLetter(task.getId(), task.getVersion(), "No handler");
-                    log.warn("task no handler, status modify to deadLetter, id={}", task.getId());
-                    return;
-                }
-
-                RetryTaskContext context = RetryTaskContext.builder()
-                        .nodeId(nodeId)
-                        .bizType(task.getBizType())
-                        .taskId(task.getTaskId())
-                        .tenantId(task.getTenantId())
-                        .headers(Map.of())
-                        .attempt(task.getRetryCount())
-                        .maxRetry(task.getMaxRetry())
-                        .deadline(task.getDeadlineTime() == null ? null : task.getDeadlineTime().toInstant(ZoneOffset.ofHours(8)))
-                        .build();
-
-                // 执行 with 超时
-                Future<Boolean> f = handlerExecutor.submit(() -> executeWith(h, task, context));
-                boolean ret = false;
-                try {
-                    ret = f.get(task.getExecuteTimeoutMs(), TimeUnit.MILLISECONDS);
-                } catch (TimeoutException te) {
-                    f.cancel(true);
-                    handleFailure(task, new RuntimeException("Handler execute time out"), context);
-                    return;
-                } catch (Throwable e) {
-                    handleFailure(task, e, context);
-                    return;
-                }
-
-                if (ret) {
-                    mapper.markSuccess(task.getId(), task.getVersion());
-                    meter.incSuccess();
-                } else {
-                    handleFailure(task, new RuntimeException("Handler returned false"), context);
-                }
-            } catch (Throwable ex) {
-                log.error("[dispatch] fatal error, {}", ex.getMessage());
-                throw ex;
-            }
-        });
-    }
-
-    /**
-     * 具体执行
-     */
-    private <T> boolean executeWith(RetryTaskHandler<T> handler,
-                                    RetryTaskEntity task, RetryTaskContext ctx) throws Exception {
-        // 反序列化为T, 类型安全
-        T payload = serializer.deserialize(task.getPayload(), handler.payloadType());
-        // 调用handler
-        return handler.execute(ctx, payload);
-    }
-
-    /**
-     * 失败处理
-     */
-    private void handleFailure(RetryTaskEntity task, Throwable ex, RetryTaskContext ctx) {
-        log.info("task failed, id={}, err={}", task.getId(), ex.getMessage());
-        meter.incFailed();
-
-        boolean retryable = failureDecider.isRetryable(ex, ctx);
-        int nextAttempt = task.getRetryCount() + 1;
-        // 截断4000字符
-        String err = "null";
-        if (!StringUtils.isBlank(ex.getMessage())) {
-            err = ex.getMessage().substring(Math.min(4000, ex.getMessage().length()));
-        }
-        // 不可重试或者达到最大重试次数, 将任务标记死信队列
-        if (!retryable || nextAttempt > task.getMaxRetry()) {
-            mapper.markDeadLetter(task.getId(), task.getVersion(), err);
-            meter.incDlq();
-            return;
-        }
-
-        Instant now = Instant.now(), deadline = task.getDeadlineTime() == null ? null : task.getDeadlineTime().toInstant(ZoneOffset.ofHours(8));
-        Instant nextTs = backoff.resolve(task.getBackoffStrategy()).next(now, nextAttempt, deadline, task, props);
-        // 设置下次触发时间
-        mapper.markPendingWithNext(
-                task.getId(), task.getVersion(), LocalDateTime.ofInstant(nextTs, ZoneOffset.ofHours(8)), nextAttempt, err);
-    }
-
-    /**
-     * 小工具：剥离 CompletionException/ExecutionException 外壳
-     */
-    private static Throwable unwrap(Throwable ex) {
-        if (ex instanceof java.util.concurrent.CompletionException ce && ce.getCause() != null) return ce.getCause();
-        if (ex instanceof java.util.concurrent.ExecutionException ee && ee.getCause() != null) return ee.getCause();
-        return ex;
     }
 }

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/mapper/RetryTaskMapper.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/mapper/RetryTaskMapper.java
@@ -83,10 +83,9 @@ public interface RetryTaskMapper extends BaseMapper<RetryTaskEntity> {
            SET lease_expire_at = DATE_ADD(CURRENT_TIMESTAMP(3), INTERVAL #{ttls} SECOND),
                updated_at = CURRENT_TIMESTAMP(3)
          WHERE id = #{id} AND state = 1 AND owner_node_id = #{nodeId}
-           AND lease_expire_at <= DATE_ADD(CURRENT_TIMESTAMP(3), INTERVAL #{renewAhead} SECOND)
       """)
     int renewLease(@Param("id") Long id, @Param("nodeId") String nodeId,
-                   @Param("ttls") long ttls, @Param("renewAhead") long renewAhead);
+                   @Param("ttls") long ttls);
 
     /**
      * 本地重试写回

--- a/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/model/entity/RetryTaskEntity.java
+++ b/retry-wheel-spring-boot3-starter/src/main/java/com/fastretry/model/entity/RetryTaskEntity.java
@@ -3,7 +3,6 @@ package com.fastretry.model.entity;
 import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
-import com.baomidou.mybatisplus.annotation.Version;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -66,19 +65,23 @@ public class RetryTaskEntity {
     /** 最后一次错误信息（可截断） */
     private String lastError;
 
-    @Version
     /** 乐观锁 */
     private Integer version;
 
-    /** 业务类型 */
+    /** 当前持有者实力Id */
+    private String OwnerNodeId;
+
+    /** 租约到期时间 */
+    private LocalDateTime leaseExpireAt;
+
+    /** 栅栏版本 */
+    private Long fenceToken;
+
     private LocalDateTime createdAt;
 
-    /** 业务类型 */
     private LocalDateTime updatedAt;
 
-    /** 业务类型 */
     private String createdBy;
 
-    /** 业务类型 */
     private String updatedBy;
 }

--- a/retry-wheel-spring-boot3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/retry-wheel-spring-boot3-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 com.fastretry.config.RetryWheelAutoConfiguration
 com.fastretry.config.RetryWheelMybatisAutoConfiguration
 com.fastretry.config.RetryWheelMetricsAutoConfiguration
+com.fastretry.config.RetryTxAutoConfiguration

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -31,7 +31,7 @@ CREATE TABLE IF NOT EXISTS retry_task (
     KEY idx_state_time_pri (state, next_trigger_time, priority),
     KEY idx_tenant_state_time (tenant_id, state, next_trigger_time),
     KEY idx_shard_priority_time ((CRC32(shard_key)), priority, next_trigger_time),
-    KEY idx_retry_task_lease ON retry_task (lease_expire_at, state) -- 按租约过期找可接管任务
+    KEY idx_retry_task_lease (lease_expire_at, state) -- 按租约过期找可接管任务
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='通用重试任务';
 
 -- 审计/事件表（可选，用于运维追踪）


### PR DESCRIPTION
feat(retry-engine): 引入粘滞租约模式，支持本地时间轮重试与安全接管

### 概要
新增 **粘滞租约模式（Sticky Lease）**：任务首次被某节点抢占后，
后续所有重试都固定在该节点的本地 HashedWheelTimer 中调度，
只有当前节点的租约过期时，其它节点才能安全接管。

### 主要变更
- **数据库**
  - `retry_task` 表新增字段：`owner_node_id`、`lease_expire_at`、`fence_token`。
  - 新建索引 `idx_retry_task_lease` 以便快速扫描过期租约任务。

- **核心逻辑**
  - **首次抢占**：`PENDING → RUNNING` 时写入 `owner_node_id`、设置 `lease_expire_at`，`fence_token` 自增。
  - **本地重试**：任务保持 `RUNNING` 状态，在当前节点本地时间轮内直接调度下一次重试，无需再次 DB 抢占。
  - **租约续约策略**：
    - 执行前：若 `now + execTimeout` 超过 `lease_expire_at - renewAhead` 则提前续约。
    - 安排下一次重试时：若下一次触发间隔跨越租约 TTL，续约 `为下次触发时间 + renewAhead`。
  - **安全接管**：其它节点定期扫描 `lease_expire_at <= now` 的任务，
    使用抢占 + `fence_token` 乐观锁确保只有一个节点成功接管。

- **配置项**
  - `retry.sticky.enabled`、`retry.sticky.lease-ttl`、`retry.sticky.renew-ahead`

### 此次更新价值
显著降低短间隔重试场景下的数据库轮询压力，
保证任务在租约有效期内“粘”在首个抢占节点快速重试，
同时通过租约过期与栅栏机制确保宕机后可安全接管。
